### PR TITLE
Joe Schmidt - Exercise 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 * Cookbook(s) -- must be original to you.
 * Single-host solution
 * Linux
-* Installs BlogEngine2 and gets it running
+* Installs django-cms and gets it running
 * Ensure we can reach the blog
 * Must use Berkshelf
 * Must use Vagrant

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 * Cookbook(s) -- must be original to you.
 * Single-host solution
 * Linux
-* Installs MariaDB, HHVM, and NGINX
-* Creates a single page that we can view via cURL
+* Installs BlogEngine2 and gets it running
+* Ensure we can reach the blog
 * Must use Berkshelf
 * Must use Vagrant
 * Community cookbook inclusion is fine, as long as it is relevant to the task
@@ -28,4 +28,3 @@
 * Reusable components
 * Rake tasks
 * Properly handle secrets
-


### PR DESCRIPTION
unzipping the tar attached and running "vagrant up" inside the directory should result in a django page accessible via web browser pointed at "5.5.5.5:8000". at the moment the page does nothing and is nothing as I was not sure what is expected, however as you will see it does run and is accessible. The bit of work for this is under recipes/default.rb as well as there being a setting.py file under the files dir. The reason I am doing a file copy over instead of a text replace is that in a real scenario there would need to be a lot more configuration done here and it would be more efficient to just copy rather than replace/add text.
[DjangoCMS.tar.gz](https://github.com/abcfinancial2/DevOps-exercise/files/1086947/DjangoCMS.tar.gz)
 